### PR TITLE
changes to argument handling

### DIFF
--- a/src/HaskellGen.hs
+++ b/src/HaskellGen.hs
@@ -32,12 +32,13 @@ data Options = Options
   , inparameters      :: [String] 
   , outparameters     :: [String] 
   , hierarchy         :: String
+  , showhelp          :: Bool
   }
   deriving (Show)
 $(deriveMods ''Options)
 
 defaultOptions :: Options
-defaultOptions = Options "" "" "" "" [] [] [] [] [] ""
+defaultOptions = Options "cgen" "" "" "" [] [] [] [] [] "" False
 
 -- haskell c type descriptor, e.g. "Ptr CChar"
 data HsCType = HsCType {

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -6,6 +6,11 @@ import Data.Char
 import Text.Regex.Posix
 import Safe
 
+import System.Exit
+import System.Environment (getProgName)
+import System.IO (hPutStrLn, stdout, stderr)
+import System.Console.GetOpt
+
 toCapital = map toUpper
 
 capitalize []     = []
@@ -61,3 +66,11 @@ expand :: [(a, [b])] -> [(a, b)]
 expand = concat . foldr go []
   where go (a, bs) acc = zip (repeat a) bs : acc
 
+usage options code = do
+  pr <- getProgName
+  hPutStrLn handle $
+    usageInfo ("Usage: " ++ pr ++ " <options> <C++ header files>") options
+  exitWith code
+    where handle = case code of
+                     ExitSuccess -> stdout
+                     _           -> stderr


### PR DESCRIPTION
Hi Antti,

These changes scratch a couple itches I have with cgen's option handling.
- made "cgen" the default outputdir to avoid accidentally clobbering source
  files in cgen and cgen-hs executables.
- added "-i" short option for interface files in all executables
- added "-g" short option for inheritance graph files in cgen-hs
- added "--help" option in all executables; factored usage+exit into
  Utils.hs.
- error messages from argument handling are printed on stderr, help output
  (when requested) is printed on stdout.
